### PR TITLE
feat: implementar plataforma web de scraping y analítica educativa

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+app.db
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,3 +1,32 @@
-# datadev
-dataScienceRep
-Nuevos cambios hechos.
+# Plataforma de Web Scraping y Analítica de Contenido
+
+Aplicación web educativa para registrar proyectos de scraping, ejecutar extracciones, procesar contenido y visualizar resultados analíticos (sentimiento y tópicos).
+
+## Stack
+- FastAPI + Jinja2 (web app)
+- SQLModel + SQLite (persistencia)
+- BeautifulSoup + httpx (scraping)
+
+## Módulos implementados
+- Gestión de usuarios y roles básicos (admin/analista)
+- Gestión de proyectos y fuentes
+- Ejecución manual de scraping por fuente
+- Almacenamiento raw y procesado
+- Análisis de sentimiento básico (positivo/negativo/neutral)
+- Dashboard con agregaciones y exportación CSV
+- Registro de historial de ejecuciones y errores
+
+## Ejecutar
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+uvicorn app.main:app --reload
+```
+
+Abrir: http://127.0.0.1:8000
+
+## Notas de cumplimiento
+- Diseñada para uso educativo y con fuentes públicas/autorizadas.
+- Incluye política por proyecto para trazabilidad de uso.
+- No implementa identificación individual; solo procesamiento agregado.

--- a/app/database.py
+++ b/app/database.py
@@ -1,0 +1,12 @@
+from sqlmodel import Session, SQLModel, create_engine
+
+engine = create_engine("sqlite:///app.db", echo=False)
+
+
+def init_db() -> None:
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session():
+    with Session(engine) as session:
+        yield session

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,140 @@
+from collections import Counter
+
+from fastapi import Depends, FastAPI, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from sqlmodel import Session, select
+
+from app.database import get_session, init_db
+from app.models.entities import CrawlRun, ProcessedDocument, Project, Source, User
+from app.services.auth import authenticate, register_user
+from app.services.scraping import run_scraping
+
+app = FastAPI(title="Plataforma de Web Scraping y Analítica")
+templates = Jinja2Templates(directory="app/templates")
+app.mount("/static", StaticFiles(directory="app/static"), name="static")
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    init_db()
+
+
+@app.get("/", response_class=HTMLResponse)
+def home(request: Request, session: Session = Depends(get_session)):
+    docs = session.exec(select(ProcessedDocument)).all()
+    by_sentiment = Counter([d.sentiment_label for d in docs])
+    by_topic = Counter([d.topic for d in docs])
+    return templates.TemplateResponse(
+        "dashboard.html",
+        {
+            "request": request,
+            "total_docs": len(docs),
+            "sentiments": dict(by_sentiment),
+            "topics": dict(by_topic),
+            "recent": docs[-10:],
+        },
+    )
+
+
+@app.get("/projects", response_class=HTMLResponse)
+def projects_page(request: Request, session: Session = Depends(get_session)):
+    projects = session.exec(select(Project)).all()
+    users = session.exec(select(User)).all()
+    return templates.TemplateResponse(
+        "projects.html", {"request": request, "projects": projects, "users": users}
+    )
+
+
+@app.post("/users/register")
+def register(
+    username: str = Form(...),
+    password: str = Form(...),
+    role: str = Form("analista"),
+    session: Session = Depends(get_session),
+):
+    register_user(session, username, password, role)
+    return RedirectResponse("/projects", status_code=303)
+
+
+@app.post("/auth/login")
+def login(
+    username: str = Form(...),
+    password: str = Form(...),
+    session: Session = Depends(get_session),
+):
+    user = authenticate(session, username, password)
+    if not user:
+        raise HTTPException(status_code=401, detail="Credenciales inválidas")
+    return {"message": "Autenticado", "user": {"id": user.id, "role": user.role}}
+
+
+@app.post("/projects")
+def create_project(
+    name: str = Form(...),
+    description: str = Form(""),
+    owner_id: int = Form(...),
+    policy: str = Form("Solo fuentes públicas/autorizadas"),
+    session: Session = Depends(get_session),
+):
+    project = Project(name=name, description=description, owner_id=owner_id, policy=policy)
+    session.add(project)
+    session.commit()
+    return RedirectResponse("/projects", status_code=303)
+
+
+@app.post("/sources")
+def create_source(
+    project_id: int = Form(...),
+    url: str = Form(...),
+    selector_rule: str = Form("body"),
+    crawl_depth: int = Form(1),
+    allowed_domains: str = Form(""),
+    excluded_domains: str = Form(""),
+    session: Session = Depends(get_session),
+):
+    source = Source(
+        project_id=project_id,
+        url=url,
+        selector_rule=selector_rule,
+        crawl_depth=crawl_depth,
+        allowed_domains=allowed_domains,
+        excluded_domains=excluded_domains,
+    )
+    session.add(source)
+    session.commit()
+    return RedirectResponse(f"/projects/{project_id}", status_code=303)
+
+
+@app.get("/projects/{project_id}", response_class=HTMLResponse)
+def project_detail(project_id: int, request: Request, session: Session = Depends(get_session)):
+    project = session.get(Project, project_id)
+    if not project:
+        raise HTTPException(status_code=404, detail="Proyecto no encontrado")
+    sources = session.exec(select(Source).where(Source.project_id == project_id)).all()
+    runs = session.exec(select(CrawlRun).where(CrawlRun.project_id == project_id)).all()
+    return templates.TemplateResponse(
+        "project_detail.html",
+        {"request": request, "project": project, "sources": sources, "runs": runs},
+    )
+
+
+@app.post("/scrape/{source_id}")
+def scrape_source(source_id: int, session: Session = Depends(get_session)):
+    source = session.get(Source, source_id)
+    if not source:
+        raise HTTPException(status_code=404, detail="Fuente no encontrada")
+    run_scraping(session, source, source.project_id)
+    return RedirectResponse(f"/projects/{source.project_id}", status_code=303)
+
+
+@app.get("/report/csv")
+def export_csv(session: Session = Depends(get_session)):
+    docs = session.exec(select(ProcessedDocument)).all()
+    header = "url,language,sentiment,score,confidence,topic\n"
+    lines = [
+        f'{d.url},{d.language},{d.sentiment_label},{d.sentiment_score:.3f},{d.confidence:.3f},{d.topic}'
+        for d in docs
+    ]
+    return HTMLResponse(header + "\n".join(lines), media_type="text/csv")

--- a/app/models/entities.py
+++ b/app/models/entities.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+
+class User(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    username: str = Field(index=True, unique=True)
+    password: str
+    role: str = Field(default="analista")
+
+
+class Project(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    description: str = ""
+    owner_id: int = Field(foreign_key="user.id")
+    policy: str = "Solo fuentes públicas/autorizadas"
+
+
+class Source(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    project_id: int = Field(foreign_key="project.id")
+    url: str
+    allowed_domains: str = ""
+    excluded_domains: str = ""
+    crawl_depth: int = 1
+    selector_rule: str = "body"
+
+
+class CrawlRun(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    project_id: int = Field(foreign_key="project.id")
+    source_id: int = Field(foreign_key="source.id")
+    status: str = "pending"
+    started_at: datetime = Field(default_factory=datetime.utcnow)
+    finished_at: Optional[datetime] = None
+    error: Optional[str] = None
+
+
+class RawDocument(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    run_id: int = Field(foreign_key="crawlrun.id")
+    url: str
+    html: str
+    fetched_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class ProcessedDocument(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    run_id: int = Field(foreign_key="crawlrun.id")
+    url: str
+    text: str
+    language: str = "unknown"
+    sentiment_label: str = "neutral"
+    sentiment_score: float = 0.0
+    confidence: float = 0.0
+    topic: str = "general"
+    created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/app/services/auth.py
+++ b/app/services/auth.py
@@ -1,0 +1,20 @@
+from sqlmodel import Session, select
+
+from app.models.entities import User
+
+
+def register_user(session: Session, username: str, password: str, role: str = "analista") -> User:
+    existing = session.exec(select(User).where(User.username == username)).first()
+    if existing:
+        return existing
+    user = User(username=username, password=password, role=role)
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    return user
+
+
+def authenticate(session: Session, username: str, password: str) -> User | None:
+    return session.exec(
+        select(User).where(User.username == username).where(User.password == password)
+    ).first()

--- a/app/services/nlp_utils.py
+++ b/app/services/nlp_utils.py
@@ -1,0 +1,39 @@
+import re
+from collections import Counter
+
+POSITIVE_WORDS = {"bueno", "excelente", "positivo", "feliz", "mejor", "aprendizaje"}
+NEGATIVE_WORDS = {"malo", "terrible", "negativo", "triste", "peor", "error"}
+
+
+def clean_text(text: str) -> str:
+    text = text.lower()
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def detect_language(text: str) -> str:
+    spanish_markers = [" el ", " la ", " de ", " y ", " que "]
+    score = sum(1 for marker in spanish_markers if marker in f" {text} ")
+    return "es" if score >= 2 else "unknown"
+
+
+def sentiment(text: str) -> tuple[str, float, float]:
+    tokens = re.findall(r"\w+", text)
+    counts = Counter(tokens)
+    pos = sum(counts[w] for w in POSITIVE_WORDS)
+    neg = sum(counts[w] for w in NEGATIVE_WORDS)
+    total = pos + neg
+    if total == 0:
+        return "neutral", 0.0, 0.5
+    score = (pos - neg) / total
+    label = "positive" if score > 0.15 else "negative" if score < -0.15 else "neutral"
+    confidence = min(0.99, 0.5 + abs(score) / 2)
+    return label, score, confidence
+
+
+def topic_from_text(text: str) -> str:
+    if "datos" in text or "analítica" in text:
+        return "datos"
+    if "educ" in text:
+        return "educación"
+    return "general"

--- a/app/services/scraping.py
+++ b/app/services/scraping.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from sqlmodel import Session
+
+from app.models.entities import CrawlRun, ProcessedDocument, RawDocument, Source
+from app.services.nlp_utils import clean_text, detect_language, sentiment, topic_from_text
+
+
+def run_scraping(session: Session, source: Source, project_id: int) -> CrawlRun:
+    run = CrawlRun(project_id=project_id, source_id=source.id, status="running")
+    session.add(run)
+    session.commit()
+    session.refresh(run)
+
+    try:
+        import httpx
+        from bs4 import BeautifulSoup
+
+        response = httpx.get(source.url, timeout=10.0)
+        response.raise_for_status()
+        html = response.text
+
+        raw = RawDocument(run_id=run.id, url=source.url, html=html)
+        session.add(raw)
+
+        soup = BeautifulSoup(html, "html.parser")
+        for tag in soup(["script", "style", "noscript"]):
+            tag.extract()
+
+        selected = soup.select(source.selector_rule or "body")
+        text = " ".join([item.get_text(" ", strip=True) for item in selected])
+        normalized = clean_text(text)
+        language = detect_language(normalized)
+        label, score, confidence = sentiment(normalized)
+        topic = topic_from_text(normalized)
+
+        processed = ProcessedDocument(
+            run_id=run.id,
+            url=source.url,
+            text=normalized,
+            language=language,
+            sentiment_label=label,
+            sentiment_score=score,
+            confidence=confidence,
+            topic=topic,
+        )
+        session.add(processed)
+
+        run.status = "completed"
+        session.add(run)
+        session.commit()
+    except Exception as exc:
+        run.status = "failed"
+        run.error = str(exc)
+        session.add(run)
+        session.commit()
+
+    session.refresh(run)
+    return run

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,0 +1,11 @@
+body { font-family: Arial, sans-serif; margin: 0; background: #f4f6f9; color: #1c2433; }
+header { background: #1f4e79; color: white; padding: 1rem 2rem; }
+nav a { color: #dceeff; margin-right: 1rem; text-decoration: none; }
+main { padding: 1.5rem 2rem; }
+.grid { display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(300px, 1fr)); }
+article, section { background: white; border-radius: 8px; padding: 1rem; margin-bottom: 1rem; }
+label { display: block; margin-bottom: 0.5rem; }
+input, select, button { width: 100%; padding: 0.5rem; margin-top: 0.3rem; }
+button { background: #1f4e79; color: white; border: none; border-radius: 6px; cursor: pointer; }
+table { width: 100%; border-collapse: collapse; }
+th, td { padding: 0.5rem; border-bottom: 1px solid #ddd; text-align: left; }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Plataforma Scraping</title>
+    <link rel="stylesheet" href="/static/style.css" />
+  </head>
+  <body>
+    <header>
+      <h1>Plataforma de Web Scraping y Analítica</h1>
+      <nav>
+        <a href="/">Dashboard</a>
+        <a href="/projects">Proyectos</a>
+        <a href="/report/csv">Exportar CSV</a>
+      </nav>
+    </header>
+    <main>{% block content %}{% endblock %}</main>
+  </body>
+</html>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+{% block content %}
+<section>
+  <h2>Dashboard</h2>
+  <p>Total de documentos procesados: <strong>{{ total_docs }}</strong></p>
+</section>
+<section class="grid">
+  <article>
+    <h3>Sentimiento</h3>
+    <ul>
+      {% for key, value in sentiments.items() %}
+      <li>{{ key }}: {{ value }}</li>
+      {% endfor %}
+    </ul>
+  </article>
+  <article>
+    <h3>Temas</h3>
+    <ul>
+      {% for key, value in topics.items() %}
+      <li>{{ key }}: {{ value }}</li>
+      {% endfor %}
+    </ul>
+  </article>
+</section>
+<section>
+  <h3>Últimos documentos</h3>
+  <table>
+    <thead>
+      <tr><th>URL</th><th>Idioma</th><th>Sentimiento</th><th>Confianza</th><th>Tema</th></tr>
+    </thead>
+    <tbody>
+      {% for d in recent %}
+      <tr>
+        <td>{{ d.url }}</td>
+        <td>{{ d.language }}</td>
+        <td>{{ d.sentiment_label }} ({{ '%.2f'|format(d.sentiment_score) }})</td>
+        <td>{{ '%.2f'|format(d.confidence) }}</td>
+        <td>{{ d.topic }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endblock %}

--- a/app/templates/project_detail.html
+++ b/app/templates/project_detail.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+{% block content %}
+<section>
+  <h2>{{ project.name }}</h2>
+  <p>{{ project.description }}</p>
+  <p><strong>Política:</strong> {{ project.policy }}</p>
+</section>
+<section class="grid">
+  <article>
+    <h3>Agregar fuente</h3>
+    <form method="post" action="/sources">
+      <input type="hidden" name="project_id" value="{{ project.id }}" />
+      <label>URL <input name="url" required /></label>
+      <label>Regla CSS <input name="selector_rule" value="body" /></label>
+      <label>Profundidad <input name="crawl_depth" type="number" min="1" value="1" /></label>
+      <label>Dominios permitidos <input name="allowed_domains" /></label>
+      <label>Dominios excluidos <input name="excluded_domains" /></label>
+      <button>Guardar fuente</button>
+    </form>
+  </article>
+  <article>
+    <h3>Fuentes</h3>
+    <ul>
+      {% for s in sources %}
+      <li>
+        {{ s.url }}
+        <form method="post" action="/scrape/{{ s.id }}" style="display:inline">
+          <button>Ejecutar scraping</button>
+        </form>
+      </li>
+      {% endfor %}
+    </ul>
+  </article>
+</section>
+<section>
+  <h3>Historial de ejecuciones</h3>
+  <table>
+    <thead><tr><th>ID</th><th>Fuente</th><th>Estado</th><th>Error</th></tr></thead>
+    <tbody>
+      {% for r in runs %}
+      <tr><td>{{ r.id }}</td><td>{{ r.source_id }}</td><td>{{ r.status }}</td><td>{{ r.error or '-' }}</td></tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endblock %}

--- a/app/templates/projects.html
+++ b/app/templates/projects.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+{% block content %}
+<section class="grid">
+  <article>
+    <h2>Registrar usuario</h2>
+    <form method="post" action="/users/register">
+      <label>Usuario <input name="username" required /></label>
+      <label>Password <input name="password" type="password" required /></label>
+      <label>Rol
+        <select name="role">
+          <option value="analista">Analista</option>
+          <option value="admin">Administrador</option>
+        </select>
+      </label>
+      <button>Crear usuario</button>
+    </form>
+  </article>
+  <article>
+    <h2>Crear proyecto</h2>
+    <form method="post" action="/projects">
+      <label>Nombre <input name="name" required /></label>
+      <label>Descripción <input name="description" /></label>
+      <label>Dueño
+        <select name="owner_id" required>
+          {% for u in users %}
+          <option value="{{ u.id }}">{{ u.username }} ({{ u.role }})</option>
+          {% endfor %}
+        </select>
+      </label>
+      <label>Política de uso <input name="policy" value="Solo fuentes públicas/autorizadas" /></label>
+      <button>Crear proyecto</button>
+    </form>
+  </article>
+</section>
+
+<section>
+  <h2>Proyectos</h2>
+  <ul>
+    {% for p in projects %}
+    <li><a href="/projects/{{ p.id }}">{{ p.name }}</a> - {{ p.description }}</li>
+    {% endfor %}
+  </ul>
+</section>
+{% endblock %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[project]
+name = "web-scraping-analytics"
+version = "0.1.0"
+description = "Plataforma educativa de scraping y analítica"
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi>=0.115.0",
+  "uvicorn>=0.30.0",
+  "sqlmodel>=0.0.22",
+  "httpx>=0.27.0",
+  "beautifulsoup4>=4.12.0",
+  "jinja2>=3.1.0",
+  "python-multipart>=0.0.9",
+  "scikit-learn>=1.5.0"
+]
+
+[project.optional-dependencies]
+dev = ["pytest>=8.0.0"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/test_scraping_service.py
+++ b/tests/test_scraping_service.py
@@ -1,0 +1,16 @@
+from app.services.nlp_utils import clean_text, detect_language, sentiment
+
+
+def test_clean_text():
+    assert clean_text(" Hola   Mundo ") == "hola mundo"
+
+
+def test_detect_language_spanish():
+    assert detect_language("este es el texto de prueba y ejemplo") == "es"
+
+
+def test_sentiment_positive():
+    label, score, confidence = sentiment("excelente aprendizaje bueno")
+    assert label == "positive"
+    assert score > 0
+    assert confidence >= 0.5


### PR DESCRIPTION
### Motivation
- Proveer una base MVP que cubra el flujo completo pedido: definición de fuentes, extracción, procesamiento, almacenamiento y visualización con enfoque educativo y cumplimiento mínimo por proyecto.
- Entregar componentes reutilizables para evolución futura hacia orquestación asíncrona, scheduler/cola, RBAC más robusto y modelos NLP más precisos.
- Garantizar trazabilidad y reglas de uso por proyecto para minimizar riesgos éticos y legales desde la arquitectura inicial.

### Description
- Se añadió una aplicación web con `FastAPI` y plantillas `Jinja2` que incluye rutas para `dashboard`, gestión de `projects`/`users`/`sources`, ejecución de `scrape` por fuente y exportación CSV (`app/main.py`).
- Se definieron entidades `SQLModel` para `User`, `Project`, `Source`, `CrawlRun`, `RawDocument` y `ProcessedDocument` para persistencia y trazabilidad (`app/models/entities.py`) y se añadió `app/database.py` con `get_session` e `init_db`.
- Se implementó el motor de scraping `run_scraping` y utilidades NLP separadas (`clean_text`, `detect_language`, `sentiment`, `topic_from_text`) para normalización, clasificación de sentimiento simple y etiquetado de tópico (`app/services/scraping.py`, `app/services/nlp_utils.py`).
- Se incorporaron plantillas UI, CSS, `pyproject.toml`, `README.md`, `.gitignore` y pruebas unitarias para utilidades NLP (`tests/test_scraping_service.py`).

### Testing
- Se ejecutó `python -m pytest -q` y las pruebas unitarias de utilidades NLP pasaron exitosamente: `3 passed`.
- Se intentó validar instalación con `pip install -e .` y el intento de construir/instalar falló en este entorno por restricciones de red/proxy al resolver dependencias externas (no relacionado con el código fuente incluido en el PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6cee7c9708333881a8edc72553cb6)